### PR TITLE
Disable GL_DEPTH_TEST in PostProcessor

### DIFF
--- a/postprocessing/src/com/bitfire/postprocessing/PostProcessor.java
+++ b/postprocessing/src/com/bitfire/postprocessing/PostProcessor.java
@@ -403,6 +403,7 @@ public final class PostProcessor implements Disposable {
 		if( count > 0 ) {
 
 			Gdx.gl.glDisable( GL20.GL_CULL_FACE );
+			Gdx.gl.glDisable( GL20.GL_DEPTH_TEST );
 
 			// render effects chain, [0,n-1]
 			if( count > 1 ) {


### PR DESCRIPTION
It took me a while to figure out why I was getting a black screen when I added PostProcessor to my app. GL_DEPTH_TEST turned out to be the culprit. 

I guess I should have disabled it before calling `postProcessor.render();`, but maybe having this call in the `render()` function might save some debugging time for somebody else... Let me know what you think.

By the way, awesome job with this lib :)
