### PR TITLE
Changed motion blur blend type: Addition to Lighten only.

### DIFF
--- a/postprocessing/src/main/resources/shaders/motionblur.fragment
+++ b/postprocessing/src/main/resources/shaders/motionblur.fragment
@@ -16,5 +16,5 @@ uniform float u_blurOpacity;
 varying vec2 v_texCoords;
 
 void main() {
-    gl_FragColor = texture2D(u_texture0, v_texCoords) + texture2D(u_texture1, v_texCoords) * u_blurOpacity;
+    gl_FragColor = max(texture2D(u_texture0, v_texCoords), texture2D(u_texture1, v_texCoords) * u_blurOpacity);
 }


### PR DESCRIPTION
This prevents brightening of image as motion blur opacity increases and results in a better effect overall in my tests. May not be the case for all scenes?