### PR TITLE
Update dependency to 1.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<name>libgdx-contribs</name>
 
 	<properties>
-		<gdx.version>0.9.9-SNAPSHOT</gdx.version>
+		<gdx.version>1.8.0</gdx.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 


### PR DESCRIPTION
Don't depend on snapshots, they won't exist forever.

Also, closes #17 , it's no longer relevant